### PR TITLE
Run original `task sync`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # taskwarrior-hooks
 Git hooks for TaskWarrior
+
+## Install Guide
+Please refer to the TaskWarrior documentation: <https://taskwarrior.org/docs/hooks_guide.html>

--- a/hooks/on-launch.git
+++ b/hooks/on-launch.git
@@ -7,9 +7,9 @@ fi
 DATA="$(echo $5 | cut -f2 -d:)"
 if [[ "$(echo $3 | cut -f2 -d:)" = "synchronize" ]]; then
     # Call original `task sync`
-	DISABLE_HOOKS=true /usr/bin/env task sync
-	# Call git push
-	/usr/bin/git -C "${DATA}" pull &> /dev/null
+    DISABLE_HOOKS=true /usr/bin/env task sync
+    # Call git push
+    /usr/bin/git -C "${DATA}" pull &> /dev/null
     /usr/bin/git -C "${DATA}" push &> /dev/null
     echo Synchronized with git upstream.
     exit 1

--- a/hooks/on-launch.git
+++ b/hooks/on-launch.git
@@ -6,7 +6,10 @@ fi
 
 DATA="$(echo $5 | cut -f2 -d:)"
 if [[ "$(echo $3 | cut -f2 -d:)" = "synchronize" ]]; then
-    /usr/bin/git -C "${DATA}" pull &> /dev/null
+    # Call original `task sync`
+	DISABLE_HOOKS=true /usr/bin/env task sync
+	# Call git push
+	/usr/bin/git -C "${DATA}" pull &> /dev/null
     /usr/bin/git -C "${DATA}" push &> /dev/null
     echo Synchronized with git upstream.
     exit 1


### PR DESCRIPTION
I keep my tasks in a remote Taskserver too which is synchronized by running `task sync`. I changed `on-launch.git` so it runs the original `task sync` command as well.